### PR TITLE
Added urllib2 to enable input directly from github

### DIFF
--- a/tools/generate-api-docs.py
+++ b/tools/generate-api-docs.py
@@ -9,6 +9,7 @@ import os
 import errno
 import glob
 import argparse
+import urllib2
 
 DEBUG = False
 
@@ -211,11 +212,21 @@ args = parser.parse_args()
 
 DEBUG = args.debug
 
+if len(args.files) == 0:
+  if DEBUG:
+    args.files.insert(0, "https://raw.githubusercontent.com/opentx/opentx/projectkk2glider/autogen_lua_docs_2/radio/src/lua_api.cpp")
+  else:
+    args.files.insert(0, "https://raw.githubusercontent.com/opentx/opentx/master/radio/src/lua_api.cpp")
+
 for fileName in args.files:
   logDebug("Opening %s" % fileName)
-  with open(fileName, "r") as inp:
-    data = inp.read()
-    parseSource(data)
+  if fileName.startswith("http"):
+    inp = urllib2.urlopen(fileName)
+  else:
+    inp = open(fileName, "r")
+  data = inp.read()
+  parseSource(data)
+  inp.close()
 
 #show gathered data
 for m in MODULES.iterkeys():


### PR DESCRIPTION
So, I learned some python today, and investigated the GitHub V3 api.

I'm suggesting the addition of urllib2 to enable pulling directly from opentx/opentx GitHub repository.

My initial thought was that the documentation update process would be part of the OpenTX production release/build. That may (or may not) be feasible at some point.

However, the addition of urllib2 uses the GitHub v3 api to generate the documentation changes directly from the production source on an 'as needed' basis.

What do you think?