### PR TITLE
Update gettxgps.md, units need fix

### DIFF
--- a/part_iii_-_opentx_lua_api_reference/general-functions-less-than-greater-than-luadoc-begin-general/gettxgps.md
+++ b/part_iii_-_opentx_lua_api_reference/general-functions-less-than-greater-than-luadoc-begin-general/gettxgps.md
@@ -15,8 +15,8 @@ none
   * `lon` \(number\) internal GPS longitude, positive is East
   * 'numsat' \(number\) current number of sats locked in by the GPS sensor
   * 'fix' \(boolean\) fix status
-  * 'alt' \(number\) internal GPS altitude in 0.1m
-  * 'speed' \(number\) internal GPSspeed in 0.1m/s
+  * 'alt' \(number\) internal GPS altitude in m
+  * 'speed' \(number\) internal GPSspeed in 1cm/s
   * 'heading'  \(number\) internal GPS ground course estimation in degrees \* 10
-  * 'hdop' \(number\)  internal GPS horizontal dilution of precision
+  * 'hdop' \(number\)  internal GPS horizontal dilution of precision (std. \* 100, good signal approx. 100)
 


### PR DESCRIPTION
I checked the getTxGPS() output with a NMEA GPS (u-Blox SAM-M8Q) and found that some units in the description here were wrong. Altitude output is in meters, step size is 1m. 
Speed is output in 1cm/s and the GPS HDOP is output 100 times higher than the standard output is, where good signal is around 1 (see e.g. https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)#Meaning_of_DOP_Values[citation_needed] ).